### PR TITLE
Compact StringIO

### DIFF
--- a/tests/codecs/test_yaml_parsing.py
+++ b/tests/codecs/test_yaml_parsing.py
@@ -17,12 +17,16 @@ from camp.entities.model import DockerFile, DockerImage, Substitution
 from camp.entities.report import SuccessfulTest, FailedTest, ErroneousTest, \
     TestSuite, TestReport
 
-from io import BytesIO, StringIO
+from io import BytesIO
 
 from sys import version_info
 
 from unittest import TestCase
 
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 class BuiltModelAreComplete(TestCase):
@@ -805,13 +809,6 @@ class TestReportsAreSerialized(TestCase):
 
     def setUp(self):
         self._output = StringIO()
-
-        # With Python 2.7, PyYAML fails to write unicode strings into
-        # a StringIO object. See Issue #289 in PyYAML. We use a
-        # BytesIO object instead in this case.
-        if version_info < (3, 5):
-            self._output = BytesIO()
-
         self._codec = YAML()
 
 


### PR DESCRIPTION
Use `StringIO.StringIO` in Python2  and `io.StringIO` in Python 3.

