### PR TITLE
Re-run AE traces experiments with different profiler frequencies

### DIFF
--- a/samples/stamp/activeeon/traces/README.MD
+++ b/samples/stamp/activeeon/traces/README.MD
@@ -4,57 +4,56 @@ This repository demonstrates how to collect traces from different Proactive conf
 `configs` folder contains **three generated Proactive configurations**. Each configuration provides a different dockerized Proactive version:
 
 - **`Config0 (Proactive + HSQLDB)`:** A preconfigured Proactive version that is configured by default to connect to the default HSQLDB database. This is the baseline config used as reference.
-- **`Config1 (Proactive + Postgres)`:** A preconfigured Proactive version that is configured to connect to the Postgres database. 
-- **`Config2 (Proactive + MySQL)`:** A preconfigured Proactive version that is configured to connect to the MySQL database. 
+- **`Config1 (Proactive + Postgres)`:** A preconfigured Proactive version that is configured to connect to the Postgres database.
+- **`Config2 (Proactive + MySQL)`:** A preconfigured Proactive version that is configured to connect to the MySQL database.
 
 The two latter configs are generated using CAMP and the first one is used as baseline or reference.
 
-The `Dockerfile` for each configuration shows how to instrument Proactive to collect traces. The script `run.sh` is executed for every configuration. It executes the following tasks:
+Since profiling basically takes a snapshot of the running app _n_ times per second (or at _n_ Hz), there is no guarantee it will collect all traces. To increase the quality of the traces, we run the profiler several times, at different frequencies. The selected frequencies are provided in demo.sh script: `FREQS=(15013 16103 17203 18301)`.
+
+The `Dockerfile` for each configuration shows how to instrument Proactive to collect traces at different frequencies. The script `run.sh` is executed for every configuration. It executes the following tasks:
 - Run the Proactive server `
 /activeeon_enterprise-pca_server-linux-x64-8.5.0-SNAPSHOT/bin/proactive-server &`. The JVM is configured with the options `-XX:+PreserveFramePointer -agentpath:/liblagent.so`
 -  Get the corresponding `PID` of the Java process
-- Attach the profiler to the Java process `java -cp /libperfagent.jar:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID` 
-- Wait until the Proactive server is up `sleep 500` 
+- Attach the profiler to the Java process `java -cp /libperfagent.jar:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $PID`
+- Wait until the Proactive server is up `sleep 500`
 - Run some tests/load using the proactive client. Here, we send and execute a `workflow-test.xml` in the scheduler `/activeeon_enterprise-pca_server-linux-x64-8.5.0-SNAPSHOT/bin/proactive-client -s /workflow-test.xml`
 - We record traces for 300 seconds. The frequency is the default one `perf record -e cpu-clock -p $PID -a -g -o /data/perf.data -- sleep 300`
 - We shutdown properly the scheduler using the proactive client.
 - We copy traces to the mounted /data folder
 > NB: The tested Proactive version being an entreprise version, we do not provide the distribution artifact but in case you need it you can contact fabien.viale@activeeeon.com.
-> 
-An advanced tutorial about docker processes profiling is available here [https://github.com/STAMP-project/docker-traces-xp](https://github.com/STAMP-project/docker-traces-xp). You can check it to get more hints about the used commands. 
-
+>
+An advanced tutorial about docker processes profiling is available here [https://github.com/STAMP-project/docker-traces-xp](https://github.com/STAMP-project/docker-traces-xp). You can check it to get more hints about the used commands.
 # Results
 
 Here are the results
 ```
 ---- Java traces ----
 
-Configuration 0 contributed 2190/6255 = 35.00 % of all unique traces
+Configuration 0 contributed 3258/8573 = 38.00 % of all unique traces
 
-Configuration 1 contributed 2563/6255 = 40.00 % of all unique traces
+Configuration 1 contributed 5916/8573 = 69.00 % of all unique traces
 
-Configuration 2 contributed 2594/6255 = 41.00 % of all unique traces
+Configuration 2 contributed 3515/8573 = 41.00 % of all unique traces
 
 ---- System traces ----
 
-Configuration 0 contributed 1363/2569 = 53.00 % of all unique traces
+Configuration 0 contributed 1438/3422 = 42.00 % of all unique traces
 
-Configuration 1 contributed 1238/2569 = 48.00 % of all unique traces
+Configuration 1 contributed 1883/3422 = 55.00 % of all unique traces
 
-Configuration 2 contributed 1225/2569 = 47.00 % of all unique traces
+Configuration 2 contributed 1575/3422 = 46.00 % of all unique traces
 ```
 -**For Proactive + HSQLDB:**
-It contributes to 35.00 % of all unique traces for Java traces and 53.00 % of all unique traces for System traces.
+It contributes to 38.00 % of all unique traces for Java traces and 42.00 % of all unique traces for System traces.
 
 -**For Proactive + Postgres:**
-It contributes to 40.00 % of all unique traces for Java traces and 48.00 % of all unique traces for System traces.
+It contributes to 69.00 % of all unique traces for Java traces and 55.00 % of all unique traces for System traces.
 
 -**For Proactive + MySQL:**
-It contributes to 41.00 % of all unique traces for Java traces and 47.00 % of all unique traces for System traces.
+It contributes to 41.00 % of all unique traces for Java traces and 46.00 % of all unique traces for System traces.
 
 The traces and raw data are available in the `profiling` folder of each config.
- 
-# Conclusion 
-The three configurations contributed differently to discover unique traces. For Java traces, the CAMP generated configs (Proactive + MySQL and Postgres) discovered more unique traces than the default HSQLDB Proactive configuration (the reference). This shows that the new generated CAMP configs allowed us to discover more JVM traces (which mean more code coverage). For System traces, we remark that the default Proactive config (the reference) uses more system calls than other generated configs. 
- 
 
+# Conclusion
+The three configurations contributed differently to discover unique traces. For Java traces, the CAMP generated configs (Proactive + MySQL and Postgres) discovered more unique traces than the default HSQLDB Proactive configuration (the reference). This shows that the new generated CAMP configs allowed us to discover more JVM traces (which mean more code coverage). For System traces, we obtain the same result as for Java traces with different traces coverage repectively, 42, 55, and 46%. We also remark that PA + Postgres has the most large traces coverage over Java and system traces compared to other configurations.

--- a/samples/stamp/activeeon/traces/configs/config0/Dockerfile
+++ b/samples/stamp/activeeon/traces/configs/config0/Dockerfile
@@ -1,5 +1,9 @@
 FROM openjdk:8
 
+ARG PROFILER_FREQ 
+
+RUN echo "$PROFILER_FREQ" > /.profiler
+
 RUN apt update
 
 RUN apt-get install -y build-essential cmake wget unzip flex bison && rm -rf /var/lib/apt/lists/*
@@ -12,7 +16,7 @@ RUN cd /root/perf-map-agent && cp out/libperfmap.so /libperfmap.so && cp out/att
 
 RUN cd /root && wget https://github.com/dcapwell/lightweight-java-profiler/archive/master.zip && unzip master.zip && rm -f master.zip
 
-RUN cd /root/lightweight-java-profiler-master &&  make
+RUN cd /root/lightweight-java-profiler-master && sed -i "s/static const int kNumInterrupts = 100;/static const int kNumInterrupts = $PROFILER_FREQ;/" src/globals.h && make
 
 RUN cp /root/lightweight-java-profiler-master/build-64/liblagent.so /liblagent.so
 

--- a/samples/stamp/activeeon/traces/configs/config0/run.sh
+++ b/samples/stamp/activeeon/traces/configs/config0/run.sh
@@ -12,7 +12,8 @@ sleep 500
 
 /activeeon_enterprise-pca_server-linux-x64-8.5.0-SNAPSHOT/bin/proactive-client -s /workflow-test.xml
 
-perf record -e cpu-clock -p $PID -a -g -o /data/perf.data -- sleep 300
+PROFILER_FREQ=$(cat /.profiler)
+perf record -e cpu-clock -F $PROFILER_FREQ -p $PID -a -g -o /data/perf.data -- sleep 300
 
 
 cp /tmp/perf*.map /data/perf-$PID.map

--- a/samples/stamp/activeeon/traces/configs/config1/Dockerfile
+++ b/samples/stamp/activeeon/traces/configs/config1/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:8
 
+ARG PROFILER_FREQ 
+RUN echo "$PROFILER_FREQ" > /.profiler
+
 RUN apt update
 
 RUN apt-get install -y build-essential cmake wget unzip flex bison && rm -rf /var/lib/apt/lists/*
@@ -12,7 +15,7 @@ RUN cd /root/perf-map-agent && cp out/libperfmap.so /libperfmap.so && cp out/att
 
 RUN cd /root && wget https://github.com/dcapwell/lightweight-java-profiler/archive/master.zip && unzip master.zip && rm -f master.zip
 
-RUN cd /root/lightweight-java-profiler-master &&  make
+RUN cd /root/lightweight-java-profiler-master && sed -i "s/static const int kNumInterrupts = 100;/static const int kNumInterrupts = $PROFILER_FREQ;/" src/globals.h && make
 
 RUN cp /root/lightweight-java-profiler-master/build-64/liblagent.so /liblagent.so
 

--- a/samples/stamp/activeeon/traces/configs/config1/run.sh
+++ b/samples/stamp/activeeon/traces/configs/config1/run.sh
@@ -12,7 +12,8 @@ sleep 500
 
 /activeeon_enterprise-pca_server-linux-x64-8.5.0-SNAPSHOT/bin/proactive-client -s /workflow-test.xml
 
-perf record -e cpu-clock -p $PID -a -g -o /data/perf.data -- sleep 300
+PROFILER_FREQ=$(cat /.profiler)
+perf record -e cpu-clock -F $PROFILER_FREQ -p $PID -a -g -o /data/perf.data -- sleep 300
 
 
 cp /tmp/perf*.map /data/perf-$PID.map

--- a/samples/stamp/activeeon/traces/configs/config2/Dockerfile
+++ b/samples/stamp/activeeon/traces/configs/config2/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:8
 
+ARG PROFILER_FREQ 
+RUN echo "$PROFILER_FREQ" > /.profiler
+
 RUN apt update
 
 RUN apt-get install -y build-essential cmake wget unzip flex bison && rm -rf /var/lib/apt/lists/*
@@ -12,7 +15,7 @@ RUN cd /root/perf-map-agent && cp out/libperfmap.so /libperfmap.so && cp out/att
 
 RUN cd /root && wget https://github.com/dcapwell/lightweight-java-profiler/archive/master.zip && unzip master.zip && rm -f master.zip
 
-RUN cd /root/lightweight-java-profiler-master &&  make
+RUN cd /root/lightweight-java-profiler-master && sed -i "s/static const int kNumInterrupts = 100;/static const int kNumInterrupts = $PROFILER_FREQ;/" src/globals.h && make
 
 RUN cp /root/lightweight-java-profiler-master/build-64/liblagent.so /liblagent.so
 

--- a/samples/stamp/activeeon/traces/configs/config2/run.sh
+++ b/samples/stamp/activeeon/traces/configs/config2/run.sh
@@ -12,7 +12,8 @@ sleep 500
 
 /activeeon_enterprise-pca_server-linux-x64-8.5.0-SNAPSHOT/bin/proactive-client -s /workflow-test.xml
 
-perf record -e cpu-clock -p $PID -a -g -o /data/perf.data -- sleep 300
+PROFILER_FREQ=$(cat /.profiler)
+perf record -e cpu-clock -F $PROFILER_FREQ -p $PID -a -g -o /data/perf.data -- sleep 300
 
 
 cp /tmp/perf*.map /data/perf-$PID.map

--- a/samples/stamp/activeeon/traces/demo.sh
+++ b/samples/stamp/activeeon/traces/demo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 LANGUAGE="java" # set this variable to anything else if your app is not Java-based
-#FREQS=(15013 16103 17203 18301) #(97 193 283) # Frequencies, in Hz, at which the profiler will be executed
+FREQS=(15013 16103 17203 18301) #(97 193 283) # Frequencies, in Hz, at which the profiler will be executed
 DIR=$(pwd)
 
 # create a global dir to aggregate all traces
@@ -31,9 +31,10 @@ FLAMEGRAPH_DIR=$DIR/FlameGraph
 function build
 {
   INDEX=$1
-
+  FREQ=$2
+  
   cd $DIR/configs/config$INDEX
-  docker build -t tracedconfig:latest .
+  docker build -t tracedconfig:latest --build-arg PROFILER_FREQ=$FREQ .
 
   cd $DIR
 }
@@ -43,7 +44,8 @@ function build
 function run
 {
   INDEX=$1
-
+  FREQ=$2
+  
   LOGDIR=$DIR/configs/config$INDEX/profiling
 
   docker run -p 8080:8080 -m 4g -v $LOGDIR:/data --cap-add=ALL --name tracedcontainer tracedconfig:latest
@@ -69,8 +71,11 @@ function run
 echo "---- Building and Running all configurations at all frequencies ----"
 for INDEX in $(seq 0 2); do
   mkdir -p $DIR/configs/config$INDEX/profiling
-    build $INDEX
-    run $INDEX 
+  for FREQ in ${FREQS[@]}; do
+  
+  build $INDEX $FREQ
+    run $INDEX $FREQ 
+done
 done
 wait
 echo "---- Cleaning a bit ----"


### PR DESCRIPTION
The goal of this PR is to provide more accurate results regarding the experiments related to docker traces extraction (to extract KPI04 from Proactive configs). For now, we run the profiler along with Proactive server several times, at different frequencies. The experiment settings and results are updated and reported in the Readme file.